### PR TITLE
fixed issue for browsers w/o redux-devtools

### DIFF
--- a/client/src/store.js
+++ b/client/src/store.js
@@ -3,12 +3,18 @@ import thunk from 'redux-thunk';
 import rootReducer from './reducers';
 
 const middlware = [thunk];
+// const store = createStore(
+//                 rootReducer,
+//                 {},
+//                 compose(
+//                   applyMiddleware(...middlware),
+//                    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+//                 ));
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const store = createStore(
-                rootReducer, 
-                {},
-                compose( 
-                  applyMiddleware(...middlware),
-                   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-                ));
-
+              rootReducer, // list of all reducers
+              {},
+              composeEnhancers(
+                applyMiddleware(...middleware)
+              ));
 export default store;


### PR DESCRIPTION
Issue:
The current issue is that for any browser that has not installed redux-devtools-extension, it will show a blank page.

proposed fix:
when the extension is not installed, use Redux compose instead.
reference: https://github.com/zalmoxisus/redux-devtools-extension#12-advanced-store-setup

Another solution is to install an npm package to manage how we want the extension to perform or exclude it from production.
https://github.com/zalmoxisus/redux-devtools-extension#13-use-redux-devtools-extension-package-from-npm